### PR TITLE
Licenses in Maturity 2

### DIFF
--- a/Current Releases/v2.0b/core/implementation/i-secure-build.md
+++ b/Current Releases/v2.0b/core/implementation/i-secure-build.md
@@ -98,7 +98,6 @@ The records include the following information about each dependency:
 * Where it is used or referenced
 * Why it is required
 * Version used
-* License
 * Source information (link to repository, author's name, etc.)
 * Open source or proprietary
 * Support and maintenance status of the component
@@ -116,6 +115,8 @@ There is an audit trail of all 3rd party libraries used in development and you k
 ### Activity
 
 Evaluate libraries to establish a whitelist of acceptable code dependencies approved for use within a project, team, or the wider organization.
+
+Add licenses of dependency to the records.
 
 Alternatively, introduce a central repository of approved dependencies that all software must be built from.
 


### PR DESCRIPTION
From my point of view the focus on lvl1 should be vulnerabilities and later licenses. I added a "continuous license check" for one of my clients and it is as much work as to include "continuous vulnerability checks". For most of my clients, the _generic impact_ from vulnerabilities is higher than from licenses. For sure, for a software selling company the impact might be higher than for a company which is using libs only for themselves with a "wrong" license.

Please also review my next PR (transitive dependencies) before you response to this suggestion.