### PR TITLE
Add missing word in Policy & Standards, Level 3

### DIFF
--- a/Current Releases/head/core/governance/g-policy-compliance.md
+++ b/Current Releases/head/core/governance/g-policy-compliance.md
@@ -86,7 +86,7 @@ Understand your organization’s compliance towards policies and standards.
 
 Develop a program to measure each application’s compliance with existing policies and standards. Mandatory requirements should be motivated and reported consistently across all teams. Whenever possible, tie compliance status into automated testing and report with each version. Compliance reporting includes the version of policies and standards and appropriate code coverage factors.
 
-Encourage non-compliant teams to review available resources such as security requirements and test scripts, to ensure non-compliance is not a result of inadequate guidance. Forward issues resulting from insufficient guidance to the teams responsible for publishing application requirements and test scripts, to include them in the future releases. Escalate issues resulting from the inability to meet policies and standards the teams that handle application security risks.
+Encourage non-compliant teams to review available resources such as security requirements and test scripts, to ensure non-compliance is not a result of inadequate guidance. Forward issues resulting from insufficient guidance to the teams responsible for publishing application requirements and test scripts, to include them in the future releases. Escalate issues resulting from the inability to meet policies and standards to the teams that handle application security risks.
 
 
 ### Maturity Questions


### PR DESCRIPTION
It seems that a word is missing in the following sentence of the activity description for _Policy & Standards_, Level 3:

> Escalate issues resulting from the inability to meet policies and **standards the teams** that handle application security risks.

Looking at the context, my best guess is that the word "to" is missing, as it makes sense that unresolved issues are forwarded towards a team which is responsible for risks. The suggested correction is as follows:

> Escalate issues resulting from the inability to meet policies and standards **to** the teams that handle application security risks.