### PR TITLE
Fixes download link for tools of the trade

### DIFF
--- a/Website/data/sud/07_tools.yaml
+++ b/Website/data/sud/07_tools.yaml
@@ -1,7 +1,7 @@
 weight: 7
 youtubeUrl: "https://www.youtube.com/watch?v=3Zg24upNDIw"
-downloadUrl: "samm-tools-of-the-trade"
-url: "/presentations/OWASP_SAMM_Tools_of_the_Trade.pptx"
+downloadUrl: "/presentations/OWASP_SAMM_Tools_of_the_Trade.pptx"
+url: "samm-tools-of-the-trade"
 name: "OWASP SAMM: Tools of the Trade"
 presenter: "John Ellingsworth"
 


### PR DESCRIPTION
There was an error in which the talk link and the download link were mixed up.

Staging: https://601c225575246a454730d8d3--elegant-wescoff-8f804a.netlify.app/user-day/