### PR TITLE
Fixes typo in Stream G-EG-A description

### DIFF
--- a/Supporting Resources/v2.0/Datamodel/Datafiles/Stream G-EG-A.yml
+++ b/Supporting Resources/v2.0/Datamodel/Datafiles/Stream G-EG-A.yml
@@ -15,7 +15,7 @@ name: Training and Awareness
 letter: A
 
 #Multi-paragraph explanation of the stream
-description: Training and awareness focuses on increasing the overall knowledge around software security anmong the different stakeholders within the organization.
+description: Training and awareness focuses on increasing the overall knowledge around software security among the different stakeholders within the organization.
 
 #Relative order of the stream within the security stream  (A=1 ; B=2)
 order: 1

--- a/Supporting Resources/v2.0/Datamodel/Datafiles/de/Stream G-EG-A.yml
+++ b/Supporting Resources/v2.0/Datamodel/Datafiles/de/Stream G-EG-A.yml
@@ -15,7 +15,7 @@ name: Training and Awareness
 letter: A
 
 #Multi-paragraph explanation of the stream
-description: Training and awareness focuses on increasing the overall knowledge around software security anmong the different stakeholders within the organization.
+description: Training and awareness focuses on increasing the overall knowledge around software security among the different stakeholders within the organization.
 
 #Relative order of the stream within the security stream  (A=1 ; B=2)
 order: 1

--- a/Supporting Resources/v2.0/Datamodel/Datafiles/en/Stream G-EG-A.yml
+++ b/Supporting Resources/v2.0/Datamodel/Datafiles/en/Stream G-EG-A.yml
@@ -15,7 +15,7 @@ name: Training and Awareness
 letter: A
 
 #Multi-paragraph explanation of the stream
-description: Training and awareness focuses on increasing the overall knowledge around software security anmong the different stakeholders within the organization.
+description: Training and awareness focuses on increasing the overall knowledge around software security among the different stakeholders within the organization.
 
 #Relative order of the stream within the security stream  (A=1 ; B=2)
 order: 1

--- a/Supporting Resources/v2.0/Datamodel/Datafiles/es/Stream G-EG-A.yml
+++ b/Supporting Resources/v2.0/Datamodel/Datafiles/es/Stream G-EG-A.yml
@@ -15,7 +15,7 @@ name: Training and Awareness
 letter: A
 
 #Multi-paragraph explanation of the stream
-description: Training and awareness focuses on increasing the overall knowledge around software security anmong the different stakeholders within the organization.
+description: Training and awareness focuses on increasing the overall knowledge around software security among the different stakeholders within the organization.
 
 #Relative order of the stream within the security stream  (A=1 ; B=2)
 order: 1


### PR DESCRIPTION
Fixes a small typo in the description of stream G-EG-A: anmong -> among